### PR TITLE
Now the Accept header items take in account specificity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "fracture/http",
     "type": "library",
     "homepage": "https://github.com/fracture/http",
-    "description": "HTTP abstraction library from Fracture PHP framework for use with composer",
+    "description": "HTTP abstraction library, extracted dependency of fracture/router.",
     "license": "BSD",
 
     "authors": [
@@ -14,7 +14,7 @@
     ],
 
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=5.5.0"
     },
 
     "autoload": {

--- a/src/Fracture/Http/Headers/Accept.php
+++ b/src/Fracture/Http/Headers/Accept.php
@@ -91,13 +91,49 @@ class Accept extends Common
         $list = [];
 
         foreach ($keys as $key) {
-            foreach ($elements[$key] as $item) {
-                unset($item['q']);
+            $sorted = $this->sortBySpecificity($elements[$key]);
+            foreach ($sorted as $item) {
+                unset($item['q'], $item['specificity']);
                 $list[] = $item;
             }
         }
 
         return $list;
+    }
+
+
+    private function sortBySpecificity($list)
+    {
+        foreach ($list as $key => $item) {
+            $list[$key]['specificity'] = $this->computeSpecificity($item);
+        }
+
+        usort($list, function($a, $b) {
+            if ($a['specificity'] === $b['specificity']) {
+                return 0;
+            }
+
+            return $a['specificity'] > $b['specificity'] ? -1 : 1;
+        });
+
+        return $list;
+    }
+
+
+    private function computeSpecificity($entry)
+    {
+        list($type, $subtype) = explode('/', $entry['value'] . '/');
+        $specificity = count($entry) - 2;
+
+        if ($type !== '*') {
+            $specificity += 1000;
+        }
+
+        if ($subtype !== '*') {
+            $specificity += 100;
+        }
+
+        return $specificity;
     }
 
 

--- a/src/Fracture/Http/Headers/Accept.php
+++ b/src/Fracture/Http/Headers/Accept.php
@@ -93,7 +93,7 @@ class Accept extends Common
         foreach ($keys as $key) {
             $sorted = $this->sortBySpecificity($elements[$key]);
             foreach ($sorted as $item) {
-                unset($item['q'], $item['specificity']);
+                unset($item['q'], $item[' spec '], $item[' index ']);
                 $list[] = $item;
             }
         }
@@ -104,16 +104,23 @@ class Accept extends Common
 
     private function sortBySpecificity($list)
     {
+        $i = 0;
+
         foreach ($list as $key => $item) {
-            $list[$key]['specificity'] = $this->computeSpecificity($item);
+            $list[$key][' spec '] = $this->computeSpecificity($item);
+            $list[$key][' index '] = $i++;
         }
 
         usort($list, function($a, $b) {
-            if ($a['specificity'] === $b['specificity']) {
-                return 0;
+            if ($a[' spec '] !== $b[' spec ']) {
+                return $a[' spec '] > $b[' spec '] ? -1 : 1;
             }
 
-            return $a['specificity'] > $b['specificity'] ? -1 : 1;
+            if ($a[' index '] !== $b[' index ']) {
+                return $a[' index '] > $b[' index '] ? 1 : -1;
+            }
+
+            return 0;
         });
 
         return $list;
@@ -176,13 +183,13 @@ class Accept extends Common
      */
     public function getPreferred($options)
     {
-        $options = $this->extractData($options);
+        $data = $this->extractData($options);
 
         if ($this->data === null) {
             return null;
         }
 
-        return $this->findFormatedEntry($this->data, $options);
+        return $this->findFormatedEntry($this->data, $data);
     }
 
 

--- a/tests/unit/Fracture/Http/Headers/AcceptTest.php
+++ b/tests/unit/Fracture/Http/Headers/AcceptTest.php
@@ -78,8 +78,68 @@ class AcceptTest extends PHPUnit_Framework_TestCase
                 ],
             ],
         ];
-
     }
+
+
+    /**
+     * @covers Fracture\Http\Headers\Accept::__construct
+     * @covers Fracture\Http\Headers\Accept::prepare
+     * @covers Fracture\Http\Headers\Accept::getParsedData
+     * @covers Fracture\Http\Headers\Accept::extractData
+     *
+     * @covers Fracture\Http\Headers\Accept::obtainGroupedElements
+     * @covers Fracture\Http\Headers\Accept::obtainSortedQualityList
+     * @covers Fracture\Http\Headers\Accept::obtainSortedElements
+     * @covers Fracture\Http\Headers\Accept::obtainAssessedItem
+     *
+     * @dataProvider provideAcceptPrecedence
+     */
+    public function testAcceptPrecedence($input, $expected)
+    {
+        $instance = new Accept($input);
+        $instance->prepare();
+
+        $this->assertEquals($expected, $instance->getParsedData());
+    }
+
+
+    public function provideAcceptPrecedence()
+    {
+        return [
+            [
+                'input' => 'type/subtype, type/subtype;param=1',
+                'expected' => [
+                    ['value' => 'type/subtype', 'param' => '1'],
+                    ['value' => 'type/subtype'],
+                ],
+            ],
+            [
+                'input' => 'type/subtype;param=1, type/subtype',
+                'expected' => [
+                    ['value' => 'type/subtype', 'param' => '1'],
+                    ['value' => 'type/subtype'],
+                ],
+            ],
+            [
+                'input' => 'text/*, text/html, text/html;level=1, */*',
+                'expected' => [
+                    ['value' => 'text/html', 'level' => '1'],
+                    ['value' => 'text/html'],
+                    ['value' => 'text/*'],
+                    ['value' => '*/*'],
+                ],
+            ],
+            [
+                'input' => 'application/*, application/json;type=1, application/json; level=1; type=2, */*',
+                'expected' => [
+                    ['value' => 'application/json', 'level' => '1', 'type' => '2'],
+                    ['value' => 'application/json', 'type' => '1'],
+                    ['value' => 'application/*'],
+                ],
+            ],
+        ];
+    }
+
 
     /**
      * @covers Fracture\Http\Headers\Accept::__construct

--- a/tests/unit/Fracture/Http/Headers/AcceptTest.php
+++ b/tests/unit/Fracture/Http/Headers/AcceptTest.php
@@ -135,6 +135,7 @@ class AcceptTest extends PHPUnit_Framework_TestCase
                     ['value' => 'application/json', 'level' => '1', 'type' => '2'],
                     ['value' => 'application/json', 'type' => '1'],
                     ['value' => 'application/*'],
+                    ['value' => '*/*'],
                 ],
             ],
         ];

--- a/tests/unit/Fracture/Http/Headers/ContentTypeTest.php
+++ b/tests/unit/Fracture/Http/Headers/ContentTypeTest.php
@@ -42,6 +42,23 @@ class ContentTypeTest extends PHPUnit_Framework_TestCase
 
     /**
      * @covers Fracture\Http\Headers\ContentType::__construct
+     * @covers Fracture\Http\Headers\ContentType::prepare
+     * @covers Fracture\Http\Headers\ContentType::contains
+     *
+     * @covers Fracture\Http\Headers\ContentType::extractData
+     */
+    public function testPreparedCustomTypeResult()
+    {
+        $instance = new ContentType('application/json;version=3');
+        $instance->prepare();
+
+        $this->assertTrue($instance->contains('application/json'));
+        $this->assertFalse($instance->contains('application/json;version=3'));
+    }
+
+
+    /**
+     * @covers Fracture\Http\Headers\ContentType::__construct
      * @covers Fracture\Http\Headers\ContentType::setValue
      * @covers Fracture\Http\Headers\ContentType::prepare
      * @covers Fracture\Http\Headers\ContentType::contains


### PR DESCRIPTION
When making the code for Accept header handing, the code that should be dealing with specificity was entirely missing. Added the related code and all test.
